### PR TITLE
Reduce wasted renders

### DIFF
--- a/src/Rating.jsx
+++ b/src/Rating.jsx
@@ -32,7 +32,7 @@ class Rating extends React.Component {
       index: indexOf(props, index),
       indexOver: undefined,
       // Default direction is left to right
-      direction: 'ltr'
+      direction: window.getComputedStyle(document.body).getPropertyValue("direction")
     };
     this.handleClick = this.handleClick.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
@@ -40,10 +40,6 @@ class Rating extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
-      // detect the computed direction style for the mounted component
-      direction: window.getComputedStyle(this.refs.container, null).getPropertyValue("direction")
-    });
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Moved the calculation of the direction to the constructor of the Rating
component.

Having a `setState` inside the `componentDidMount` is not a good thing
to do, to begin with, because [it forces a
re-render](https://facebook.github.io/react/docs/react-component.html#componentdidmount).

Since it is not much likely that the text direction of the page will
change during use, I moved the calculation to the constructor.